### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "codocx": "./dist/index.js"
     },
     "scripts": {
-        "start": "node --no-warnings=ExperimentalWarning --loader ts-node/esm src\\index.ts",
+        "start": "node --no-warnings=ExperimentalWarning --loader ts-node/esm src/index.ts",
         "clean": "rimraf ./dist/ ./exec/",
         "build": "npm run clean && tsup",
         "pub": "npm run build && npm version patch && npm publish",


### PR DESCRIPTION
Na linha doze, foi alterado o elemento: "src\\index.ts" para "src\index.ts", pois ao executar npm start estava recebendo o erro abaixo:

x201s:/git/codocx# npm start

> codocx@1.0.5 start
> node --no-warnings=ExperimentalWarning --loader ts-node/esm src\index.ts

node:internal/modules/run_main:129
    triggerUncaughtException(
    ^
Error: Cannot find module '/git/codocx/srcindex.ts' imported from /git/codocx/
    at finalizeResolution (/git/codocx/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:366:11)
    at moduleResolve (/git/codocx/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:801:10)
    at Object.defaultResolve (/git/codocx/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:912:11)
    at /git/codocx/node_modules/ts-node/src/esm.ts:218:35
    at entrypointFallback (/git/codocx/node_modules/ts-node/src/esm.ts:168:34)
    at /git/codocx/node_modules/ts-node/src/esm.ts:217:14
    at addShortCircuitFlag (/git/codocx/node_modules/ts-node/src/esm.ts:409:21)
    at resolve (/git/codocx/node_modules/ts-node/src/esm.ts:197:12)
    at nextResolve (node:internal/modules/esm/hooks:866:28)
    at Hooks.resolve (node:internal/modules/esm/hooks:304:30)

Node.js v20.15.1